### PR TITLE
Fix the issue #1

### DIFF
--- a/src/Traits/Convinience.php
+++ b/src/Traits/Convinience.php
@@ -19,8 +19,8 @@ trait Convinience
     {
         $base64Types = [Config::BASE64_ENCODE, Config::BASE64_DECODE];
 
-        if (! in_array($mode, $base64Types, true)) {
-            throw new InvalidConfigOptionException('$mode must be one of ' . implode(', ', $base64Types));
+        if (! function_exists($mode)) {
+            throw new InvalidConfigOptionException("Invalid $mode specified");
         }
 
         return new static($mode($this->string));


### PR DESCRIPTION
As title, fix the issue #1.
And using ```function_exists``` to check whether the mode is specified because the const functions are ```base64_encode``` and ```base64_decode```. We can check whether the two functions are existed.