### PR TITLE
Added  JsonSerializable support

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -10,7 +10,7 @@ use PHLAK\Twine\Traits\Hashable;
 use PHLAK\Twine\Traits\Segmentable;
 use PHLAK\Twine\Traits\Transformable;
 
-class Str implements \ArrayAccess
+class Str implements \ArrayAccess, \JsonSerializable
 {
     use Aliases,
         ArrayAccess,
@@ -39,6 +39,18 @@ class Str implements \ArrayAccess
      * @return string The string
      */
     public function __toString()
+    {
+        return $this->string;
+    }
+
+
+    /**
+     * jsonSerialize method. Returns the object as a string when json_encode is called upon Str.
+     *
+     * @return string The string
+     */
+
+    public function jsonSerialize()
     {
         return $this->string;
     }

--- a/src/Str.php
+++ b/src/Str.php
@@ -43,13 +43,11 @@ class Str implements \ArrayAccess, \JsonSerializable
         return $this->string;
     }
 
-
     /**
      * jsonSerialize method. Returns the object as a string when json_encode is called upon Str.
      *
      * @return string The string
      */
-
     public function jsonSerialize()
     {
         return $this->string;

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -22,6 +22,21 @@ class StrTest extends TestCase
         $this->assertEquals('p', $string[5]);
     }
 
+    public function test_it_can_be_converted_to_a_string_when_serialized()
+    {
+        $string = new Twine\Str('john pinkerton');
+
+        $array = [
+            'name' => $string
+        ];
+
+        $json  = json_encode($array);
+        $array = json_decode($json, true);
+
+        $this->assertEquals('john pinkerton', $array['name']);
+    }
+
+
     public function test_it_thows_an_exception_when_modifyinging_characters_with_array_notation()
     {
         $string = new Twine\Str('john pinkerton');


### PR DESCRIPTION
Added the ability to convert the Str object to a string when json_encode() is being called upon it. Also added a test to confirm the functionality.

This way the Str object will transform itself back into a string when it get encoded to JSON, for example when you want to pass it through an JSON based API. 

Previously it would just convert into '{}' unless you cast it back to string manually before encoding.