### PR TITLE
Optimize hex encoding by using array_reduce.

### DIFF
--- a/src/Traits/Encodable.php
+++ b/src/Traits/Encodable.php
@@ -55,11 +55,11 @@ trait Encodable
 
         switch ($mode) {
             case Config\Hex::ENCODE:
-                $characters = array_map(function ($char) {
-                    return '\x' . dechex(ord($char));
-                }, str_split($this->string));
+                $string = array_reduce(str_split($this->string), function ($str, $char) {
+                    $str .= '\x' . dechex(ord($char));
 
-                $string = implode($characters);
+                    return $str;
+                }, '');
                 break;
 
             case Config\Hex::DECODE:


### PR DESCRIPTION
This is a minor optimization in terms of performance when encoding to hex.  It removes an array (`$words`), and removes an `implode`.  This really only matters when encoding a large amount of text, or if you were calling the method thousands of times.

Performance aside, using `array_reduce` is more "correct" anyways.  By "correct" I mean, you are reducing an array of characters to a new value.  Thus, using `array_reduce` makes more sense.