### PR TITLE
Optimize lowercase words, and handle words after line breaks and tabs.

### DIFF
--- a/src/Traits/Transformable.php
+++ b/src/Traits/Transformable.php
@@ -85,11 +85,13 @@ trait Transformable
         Config\Lowercase::validateOption($mode);
 
         if ($mode == Config\Lowercase::WORDS) {
-            $words = array_map(function ($word) {
-                return lcfirst($word);
-            }, explode(' ', $this->string));
+            // A word is defined as a series of non-space characters. We specifically
+            // locate only words needing modification (start with a capital letter).
+            $string = preg_replace_callback('/([A-Z][^\s]*)/', function ($matched) {
+                return lcfirst($matched[1]);
+            }, $this->string);
 
-            return new static(implode(' ', $words));
+            return new static($string);
         }
 
         return new static($mode($this->string));

--- a/tests/TransformableTest.php
+++ b/tests/TransformableTest.php
@@ -99,12 +99,12 @@ class TransformableTest extends TestCase
 
     public function test_it_can_lowercase_the_first_letter_of_each_word()
     {
-        $string = new Twine\Str('JOHN PINKERTON');
+        $string = new Twine\Str("JOHN PINKERTON\nJOHN\tPINKERTON");
 
         $lcWords = $string->lowercase(Twine\Config\Lowercase::WORDS);
 
         $this->assertInstanceOf(Twine\Str::class, $lcWords);
-        $this->assertEquals('jOHN pINKERTON', $lcWords);
+        $this->assertEquals("jOHN pINKERTON\njOHN\tpINKERTON", $lcWords);
     }
 
     public function test_it_throws_an_exception_when_lowercasing_with_an_invalid_config_option()


### PR DESCRIPTION
Lowercasing words is very inefficient with long strings due to it creating multiple arrays of words.  This replaces the `array_map` with `preg_replace_callback`.

It also only handled lowercasing words with a space before them.  So, the first word after a line break or tab would not have had its first character lowercased (because of `explode(' ', $this->string)`).  This is inconsistent with how `uppercaseWords` works.  This code also fixes that.

**Unicode Characters Note:**
In the RegEx, we use `[A-Z]` to locate words needing lowercased, thus ignoring non-ascii characters.  However, given that the rest of the library doesn't use the`mb_*` functions, this is consistent with the other methods.

If an effort is made to make this library work with multibyte strings, the RegEx can be modified from `/([A-Z][^\s]*)/` to `/(\p{Lu}[^\s]*)/u`.