### PR TITLE
Implement explode

### DIFF
--- a/src/Traits/Transformable.php
+++ b/src/Traits/Transformable.php
@@ -167,4 +167,28 @@ trait Transformable
     {
         return $this->replace($search, '');
     }
+
+    /**
+     * @param string $delimiter The string to split on.
+     * @param int $limit
+     *   The maximum number of items in the resulting array.
+     *   - If $limit is positive, the resulting array will contain $limit items,
+     *     with the last element containing the rest of the string
+     *   - If $limit is negative, all elements except the last $limit are
+     *     returned
+     *   - If $limit is null, all elements will be returned
+     *   - If $limit is 0, it will be treated as being 1.
+     *
+     * @return array|false
+     *   Returns false and issues a warning if $delimiter is the empty string.
+     */
+    public function explode(string $delimiter, int $limit = null)
+    {
+        // We have to explicitly check if $limit is passed to the method
+        // because if we just pass `null` to the native explode function, it
+        // gets treated as `0`.
+        return $limit !== null
+            ? explode($delimiter, $this->string, $limit)
+            : explode($delimiter, $this->string);
+    }
 }

--- a/tests/Methods/ExplodeTest.php
+++ b/tests/Methods/ExplodeTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 class ExplodeTest extends TestCase
 {
-
     /**
      * @dataProvider explode_data_provider
      */

--- a/tests/Methods/ExplodeTest.php
+++ b/tests/Methods/ExplodeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PHLAK\Twine\Tests;
+
+use PHLAK\Twine;
+use PHPUnit\Framework\TestCase;
+
+class ExplodeTest extends TestCase
+{
+
+    /**
+     * @dataProvider explode_data_provider
+     */
+    public function test_it_splits_a_string_by_a_given_string($input, $delimiter, $limit, $expected)
+    {
+        $string = new Twine\Str($input);
+
+        $parts = $string->explode($delimiter, $limit);
+
+        $this->assertEquals($expected, $parts);
+    }
+
+    public function explode_data_provider()
+    {
+        return [
+            'split by string' => ['john pinkerton', ' ', null, ['john', 'pinkerton']],
+            'multibyte string split' => ['宮本 茂', '本 ', null, ['宮', '茂']],
+            'negative limit' => ['john pinkerton', ' ', -1, ['john']],
+            'positive limit' => ['1 2 3', ' ', 2, ['1', '2 3']],
+            'limit 0' => ['1 2 3', ' ', 0, ['1 2 3']]
+        ];
+    }
+}


### PR DESCRIPTION
As mentioned in #19, this PR implements the explode method. Some remarks:

- Do we want to keep the method name `explode`, or replace it with for example `split`? Personally I'd keep `explode` to remain consistent
- Are we interested in keeping the `$limit` parameter? I've kept it because the native `explode` method provides it, but I don't know if it is that useful to have. 