### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "issues": "https://github.com/PHLAK/Twine/issues"
     },
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.3",

--- a/src/Traits/Encodable.php
+++ b/src/Traits/Encodable.php
@@ -3,6 +3,7 @@
 namespace PHLAK\Twine\Traits;
 
 use PHLAK\Twine\Config;
+use RuntimeException;
 
 trait Encodable
 {

--- a/src/Traits/Encodable.php
+++ b/src/Traits/Encodable.php
@@ -3,7 +3,6 @@
 namespace PHLAK\Twine\Traits;
 
 use PHLAK\Twine\Config;
-use RuntimeException;
 
 trait Encodable
 {

--- a/tests/Methods/EndsWithTest.php
+++ b/tests/Methods/EndsWithTest.php
@@ -22,4 +22,18 @@ class EndsWithTest extends TestCase
         $this->assertTrue($string->endsWith('茂'));
         $this->assertFalse($string->endsWith('宮本'));
     }
+
+    public function test_it_should_return_false_with_passing_empty_string_to_constructor()
+    {
+        $string = new Twine\Str('');
+
+        $this->assertFalse($string->endsWith('john pinkerton'));
+    }
+
+    public function test_it_should_return_false_with_passing_empty_string_to_method()
+    {
+        $string = new Twine\Str('john pinkerton');
+
+        $this->assertFalse($string->endsWith(''));
+    }
 }

--- a/tests/Methods/StartsWithTest.php
+++ b/tests/Methods/StartsWithTest.php
@@ -22,4 +22,18 @@ class StartsWith extends TestCase
         $this->assertTrue($string->startsWith('宮本'));
         $this->assertFalse($string->startsWith('茂'));
     }
+
+    public function test_it_should_return_false_with_passing_empty_string_to_constructor()
+    {
+        $string = new Twine\Str('');
+
+        $this->assertFalse($string->startsWith('john pinkerton'));
+    }
+
+    public function test_it_should_return_false_with_passing_empty_string_to_method()
+    {
+        $string = new Twine\Str('john pinkerton');
+
+        $this->assertFalse($string->startsWith(''));
+    }
 }


### PR DESCRIPTION
# Changed log
- Add missed test cases for `startsWith` and `endsWith` methods inside `Comparable` trait.
- Remove the `RuntimeException` in default condition inside `Encodable\hex` trait because this default condition will not be triggered. The `Config\Hex::validateOption($mode);` always checks the mode is valid firstly.