### PR TITLE
Udated deprecated method

### DIFF
--- a/tests/Methods/BcryptTest.php
+++ b/tests/Methods/BcryptTest.php
@@ -14,7 +14,7 @@ class BcryptTest extends TestCase
         $bcrypt = $string->bcrypt();
 
         $this->assertInstanceOf(Twine\Str::class, $bcrypt);
-        $this->assertRegExp('/\$2y\$10\$[a-zA-Z0-9+.\/]{53}/', (string) $bcrypt);
+        $this->assertMatchesRegularExpression('/\$2y\$10\$[a-zA-Z0-9+.\/]{53}/', (string) $bcrypt);
     }
 
     public function test_a_multibyte_string_can_be_hashed_with_bcrypt()
@@ -24,7 +24,7 @@ class BcryptTest extends TestCase
         $bcrypt = $string->bcrypt();
 
         $this->assertInstanceOf(Twine\Str::class, $bcrypt);
-        $this->assertRegExp('/\$2y\$10\$[a-zA-Z0-9+.\/]{53}/', (string) $bcrypt);
+        $this->assertMatchesRegularExpression('/\$2y\$10\$[a-zA-Z0-9+.\/]{53}/', (string) $bcrypt);
     }
 
     public function test_it_preserves_encoding()

--- a/tests/Methods/EncryptTest.php
+++ b/tests/Methods/EncryptTest.php
@@ -15,7 +15,7 @@ class EncryptTest extends TestCase
         $encrypted = $string->encrypt('secret');
 
         $this->assertInstanceOf(Twine\Str::class, $encrypted);
-        $this->assertRegExp('/[a-zA-Z0-9=+\/]+/', (string) $encrypted);
+        $this->assertMatchesRegularExpression('/[a-zA-Z0-9=+\/]+/', (string) $encrypted);
 
         return $encrypted;
     }
@@ -36,7 +36,7 @@ class EncryptTest extends TestCase
         $encrypted = $string->encrypt('secret');
 
         $this->assertInstanceOf(Twine\Str::class, $encrypted);
-        $this->assertRegExp('/[a-zA-Z0-9=+\/]+/', (string) $encrypted);
+        $this->assertMatchesRegularExpression('/[a-zA-Z0-9=+\/]+/', (string) $encrypted);
 
         return $encrypted;
     }

--- a/tests/Methods/ShuffleTest.php
+++ b/tests/Methods/ShuffleTest.php
@@ -19,7 +19,7 @@ class ShuffleTest extends TestCase
 
         $this->assertInstanceOf(Twine\Str::class, $shuffled);
         $this->assertNotEquals($string, $shuffled);
-        $this->assertRegExp('/[ ehijknoprt]{14}/', (string) $shuffled);
+        $this->assertMatchesRegularExpression('/[ ehijknoprt]{14}/', (string) $shuffled);
     }
 
     public function test_a_multibyte_string_can_be_shuffled()
@@ -34,7 +34,7 @@ class ShuffleTest extends TestCase
 
         $this->assertInstanceOf(Twine\Str::class, $shuffled);
         $this->assertNotEquals($string, $shuffled);
-        $this->assertRegExp('/[ 本天任宮堂茂]{7}/', (string) $shuffled);
+        $this->assertMatchesRegularExpression('/[ 本天任宮堂茂]{7}/', (string) $shuffled);
     }
 
     public function test_it_preserves_encoding()


### PR DESCRIPTION
Changed PhpUnit's assertRegExp to assertMatchesRegularExpression following deprecation notice:

"assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead."