### PR TITLE
Add MBSTRING Extension Required to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require": {
         "php": ">=7.2",
+        "ext-mbstring": "*",
         "ext-openssl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Since Twine relies on PHP's multi-byte string (mb_*) functions available (only) when the MBSTRING extension for PHP is loaded, add MBSTRING extension requirement to composer.json. Reference #41